### PR TITLE
Active Directory works without a binding account

### DIFF
--- a/ActiveDirectoryLDAPServer.php
+++ b/ActiveDirectoryLDAPServer.php
@@ -15,7 +15,11 @@ class ActiveDirectoryLDAPServer extends LDAPServer {
 
     // Check if it authenticates the service account
     error_reporting(E_ALL^ E_WARNING);
-    @$bind_service_account = ldap_bind($this->con,qa_opt('ldap_login_ad_bind'), qa_opt('ldap_login_ad_pwd'));
+    if(!qa_opt('ldap_login_ad_pwd')) {
+        @$bind_service_account = ldap_bind($this->con);
+    } else {
+        @$bind_service_account = ldap_bind($this->con,qa_opt('ldap_login_ad_bind'), qa_opt('ldap_login_ad_pwd'));
+    }
 
     if($bind_service_account) {
       $attributes = array('dn');


### PR DESCRIPTION
Hi, 
This is the pull request so active directory can be used a binding account. I have tested this works on AD without a binding account but am not able to test that it works on AD with a binding account (since i dont have one).

Best
Patrick
