### PR TITLE
Simplified authentication through Active Directory.

### DIFF
--- a/ActiveDirectoryLDAPServer.php
+++ b/ActiveDirectoryLDAPServer.php
@@ -7,62 +7,46 @@
 class ActiveDirectoryLDAPServer extends LDAPServer {
   private $dn;
   private $authenticatedUser;
+  private $fname;
+  private $sname;
+  private $mail;
 
   public function bindToLDAP($user,$pass) {
     $filter = "(".qa_opt('ldap_authentication_attribute')."=".$user.")";
 
     // Check if it authenticates the service account
     error_reporting(E_ALL^ E_WARNING);
-    if(!qa_opt('ldap_login_ad_pwd')) {
-        @$bind_service_account = ldap_bind($this->con);
-    } else {
-        @$bind_service_account = ldap_bind($this->con,qa_opt('ldap_login_ad_bind'), qa_opt('ldap_login_ad_pwd'));
-    }
-
-    if($bind_service_account) {
-      $attributes = array('dn');
-      $search = ldap_search($this->con, qa_opt('ldap_login_ad_basedn'), $filter, $attributes);
-      $data = ldap_get_entries($this->con, $search);
-    } else {
+    
+    $bind_user = ldap_bind($this->con, qa_opt('ldap_login_ad_bind_domain').'\\'.$user, $pass);
+    if (!$bind_user) {
       return false;
     }
-
-    // if the user is found, try to authenticate with his DN and password entered
-    if (isset($data[0])) {
-      $this->dn = $data[0]['dn'];
-      @$bind_user = ldap_bind($this->con, $this->dn, $pass);
-    } else {
-      return false;
-    }
-
-    error_reporting(E_ALL);
-
-    //we have to preserve the username entered if auth was succesfull
-    if($bind_user) {
-      $this->authenticatedUser=$user;
-      return($bind_user);
-    }
-
-    return false;
-  }
-
-  public function getUserAttributes() {
+    
     $fname_tag = qa_opt('ldap_login_fname');
     $sname_tag = qa_opt('ldap_login_sname');
     $mail_tag = qa_opt('ldap_login_mail');
-
-    $filter = qa_opt('ldap_login_filter');
+    
     $attributes = array('dn', $fname_tag, $sname_tag, $mail_tag);
 
-    // The DN is known so just use it to read attributes
-    $read = ldap_read($this->con, $this->dn, $filter, $attributes);
-    $data = ldap_get_entries($this->con, $read);
+    $search = ldap_search($this->con, qa_opt('ldap_login_ad_basedn'), $filter, $attributes);
+    $data = ldap_get_entries($this->con, $search);
 
-    $fname = $data[0][strtolower($fname_tag)][0];
-    $sname = $data[0][strtolower($sname_tag)][0];
-    $mail  = $data[0][strtolower($mail_tag)][0];
+    if (!isset($data[0])) {
+      return false;
+    }
+    
+    $this->authenticatedUser = $user;
+    $this->fname = $data[0][strtolower($fname_tag)][0];
+    $this->sname = $data[0][strtolower($sname_tag)][0];
+    $this->mail = $data[0][strtolower($mail_tag)][0];
 
-    return array( $fname, $sname, $mail, $this->authenticatedUser);
+    error_reporting(E_ALL);
+
+    return true;
+  }
+
+  public function getUserAttributes() {
+    return array( $this->fname, $this->sname, $this->mail, $this->authenticatedUser);
   }
 }
 

--- a/ldap-login-admin-form.php
+++ b/ldap-login-admin-form.php
@@ -15,7 +15,7 @@ class ldap_login_admin_form {
     if ($option=='ldap_login_filter')
       return '(objectClass=*)';
     if ($option=='ldap_login_fname')
-      return 'givenname';
+      return 'givenName';
     if ($option=='ldap_login_sname')
       return 'sn';
     if ($option=='ldap_login_mail')
@@ -23,12 +23,10 @@ class ldap_login_admin_form {
 
     if ($option=='ldap_login_ad')
       return true;
-    if ($option=='ldap_login_ad_bind')
-      return 'CN=serviceaccount,CN=Managed Service Accounts,DC=contoso,DC=local';
-    if ($option=='ldap_login_ad_pwd')
-      return '12345678';
+    if ($option=='ldap_login_ad_bind_domain')
+      return 'CONTOSO';
     if ($option=='ldap_login_ad_basedn')
-      return 'OU=Users,DC=contoso,DC=local';
+      return 'DC=contoso,DC=local';
 
     if ($option=='ldap_login_generic_search')
       return 'uid=USERNAME,OU=people,DC=company,DC=local/uid=USERNAME,OU=people3,DC=company,DC=local';
@@ -56,7 +54,7 @@ class ldap_login_admin_form {
       qa_opt('ldap_login_mail', qa_post_text('ldap_login_mail_field'));
 
       qa_opt('ldap_login_ad', (bool) qa_post_text('ldap_login_ad_field'));
-      qa_opt('ldap_login_ad_bind', qa_post_text('ldap_login_ad_bind_field'));
+      qa_opt('ldap_login_ad_bind_domain', qa_post_text('ldap_login_ad_bind_domain_field'));
       qa_opt('ldap_login_ad_pwd', qa_post_text('ldap_login_ad_pwd_field'));
       qa_opt('ldap_login_ad_basedn', qa_post_text('ldap_login_ad_basedn_field'));
       qa_opt('ldap_login_generic_search', qa_post_text('ldap_login_generic_search_field'));
@@ -71,7 +69,7 @@ class ldap_login_admin_form {
 
     qa_set_display_rules($qa_content, array(
       'ldap_login_allow_registration_display' => 'ldap_login_allow_normal_field',
-      'ldap_login_ad_bind_display' => 'ldap_login_ad_field',
+      'ldap_login_ad_bind_domain_display' => 'ldap_login_ad_field',
       'ldap_login_ad_pwd_display' => 'ldap_login_ad_field',
       'ldap_login_ad_basedn_display' => 'ldap_login_ad_field',
       'ldap_login_generic_search_display' => '!ldap_login_ad_field',
@@ -89,7 +87,7 @@ class ldap_login_admin_form {
         ),
 
         array(
-          'label' => 'Port for LDAP Server (389 for non-SSL, 636 for SSL)',
+          'label' => 'Port for LDAP Server (389 for non-SSL, 636 for SSL, 3268 for AD non-SSL, 3269 for AD SSL)',
           'type' => 'number',
           'value' => qa_opt('ldap_login_port'),
           'tags' => 'name="ldap_login_port_field"',
@@ -131,19 +129,11 @@ class ldap_login_admin_form {
         ),
 
         array(
-          'id' => 'ldap_login_ad_bind_display',
-          'label' => 'Binding account for AD',
+          'id' => 'ldap_login_ad_bind_domain_display',
+          'label' => 'Binding domain for AD',
           'type' => 'text',
-          'value' => qa_opt('ldap_login_ad_bind'),
-          'tags' => 'name="ldap_login_ad_bind_field"',
-        ),
-
-        array(
-          'id' => 'ldap_login_ad_pwd_display',
-          'label' => 'Password for AD binging accout',
-          'type' => 'text',
-          'value' => qa_opt('ldap_login_ad_pwd'),
-          'tags' => 'name="ldap_login_ad_pwd_field"',
+          'value' => qa_opt('ldap_login_ad_bind_domain'),
+          'tags' => 'name="ldap_login_ad_bind_domain_field"',
         ),
 
         array(


### PR DESCRIPTION
If you bind to a specific AD port, you can use the user credentials to bind to AD. See https://github.com/grafana/grafana/issues/10040 and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd772723(v=ws.10) for more information.

These changes apply this. It removes the service account parameters (username and password) and replaces it with a single bind domain setting. The ldap_connect is then done using CONTOSO\$user and $password. Also simplified retrieving the user account details by retrieving it as part of the intial connect attempt.

I'm not sure whether this makes sense to merge since it's a breaking change. This will cause the connection to break until the domain has been set. If you have any suggestions to modify this PR to make it more appropriate, please feel free to let me know.